### PR TITLE
Added tests & ability to edit some stack variable types

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,15 +24,23 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DSDB_BUILD_TESTING=ON && cmake -B ${{github.workspace}}/build_noswagger -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DSDB_ENABLE_OATPP_SWAGGER=OFF
 
-    - name: Build
+    - name: Build Sample App
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target "sample_app"
+
+    - name: Build Sample App (No Swagger)
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build_noswagger --config ${{env.BUILD_TYPE}} --target "sample_app"
+
+    - name: Build Tests
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target "squirrel_debugger_tests"
 
     - name: Test
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ctest --output-on-failure -C ${{env.BUILD_TYPE}}
       

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,9 @@ Thumbs.db
 *.wmv
 
 cmake-build-debug/
+cmake-build-release/
 .vs/
 *.user
 out/
 /build
+/Testing/Temporary/CTestCostData.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,12 @@ project(vscode_quirrel_debugger)
 
 set(CMAKE_CXX_STANDARD 17)
 
+set(SDB_BUILD_TESTING OFF CACHE BOOL "Enable unit tests")
+
+if(SDB_BUILD_TESTING)
+    enable_testing()
+endif()
+
 add_subdirectory(interfaces)
 add_subdirectory(embedded_server)
 add_subdirectory(squirrel_debugger)

--- a/embedded_server/CMakeLists.txt
+++ b/embedded_server/CMakeLists.txt
@@ -4,6 +4,8 @@ project(embedded_server)
 
 set(CMAKE_CXX_STANDARD 17)
 
+option(SDB_ENABLE_OATPP_SWAGGER "Build OATPP-Swagger and add swagger endpoints" ON)
+
 set(SDB_DEPENDENCIES_OATPP "FETCHCONTENT" CACHE STRING "Location where to find oatpp modules. can be [INSTALLED|FETCHCONTENT]")
 set(SDB_DEPENDENCIES_OATPP_INSTALLED INSTALLED)
 set(SDB_DEPENDENCIES_OATPP_FETCHCONTENT FETCHCONTENT)
@@ -53,13 +55,15 @@ if(SDB_DEPENDENCIES_OATPP STREQUAL SDB_DEPENDENCIES_OATPP_FETCHCONTENT)
             GIT_REPOSITORY https://github.com/oatpp/oatpp-websocket.git
             GIT_TAG 36c3ceaf4706e54390d020390081203fa2cc693c
     )
-    set(OATPP_BUILD_TESTS OFF)
+    set(OATPP_BUILD_TESTS OFF CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(oatpp)
 
     set(OATPP_MODULES_LOCATION CUSTOM CACHE STRING "" FORCE)
     set(OATPP_DIR_SRC ${oatpp_SOURCE_DIR} CACHE STRING "" FORCE)
     set(OATPP_DIR_LIB ${oatpp_BINARY_DIR} CACHE STRING "" FORCE)
-    FetchContent_MakeAvailable(oatpp-swagger)
+    if(SDB_ENABLE_OATPP_SWAGGER)
+        FetchContent_MakeAvailable(oatpp-swagger)
+    endif()
 
     FetchContent_MakeAvailable(oatpp-websocket)
 elseif(SDB_DEPENDENCIES_OATPP STREQUAL SDB_DEPENDENCIES_OATPP_INSTALLED)
@@ -68,14 +72,17 @@ else()
     message("FATAL_ERROR Unknown location to find squirrel '${SDB_DEPENDENCIES_OATPP}'")
 endif()
 
-get_target_property(OATPP_SWAGGER_SOURCE_DIR oatpp-swagger SOURCE_DIR)
-add_definitions(
-        ## define path to swagger-ui static resources folder
-        -DOATPP_SWAGGER_RES_PATH="${OATPP_SWAGGER_SOURCE_DIR}/../res"
-        )
+if(SDB_ENABLE_OATPP_SWAGGER)
+    get_target_property(OATPP_SWAGGER_SOURCE_DIR oatpp-swagger SOURCE_DIR)
+    add_definitions(
+            ## define path to swagger-ui static resources folder
+            -DOATPP_SWAGGER_RES_PATH="${OATPP_SWAGGER_SOURCE_DIR}/../res"
+            -DSDB_ENABLE_OATPP_SWAGGER
+    )
+    target_link_libraries(${PROJECT_NAME} oatpp-swagger)
+endif()
 
 target_link_libraries(${PROJECT_NAME}
         sdb::interfaces
         oatpp
-        oatpp-swagger
         oatpp-websocket)

--- a/embedded_server/SwaggerComponent.h
+++ b/embedded_server/SwaggerComponent.h
@@ -2,15 +2,19 @@
 #ifndef SWAGGER_COMPONENT_H
 #define SWAGGER_COMPONENT_H
 
+#ifdef SDB_ENABLE_OATPP_SWAGGER
 #include "oatpp-swagger/Model.hpp"
 #include "oatpp-swagger/Resources.hpp"
+
+#include <sstream>
+#endif
+
 #include "oatpp/core/macro/component.hpp"
 
 #include "ListenerConfig.h"
 
-#include <sstream>
-
 namespace sdb {
+#ifdef SDB_ENABLE_OATPP_SWAGGER
 /**
  *  Swagger ui is served at
  *  http://host:port/swagger/ui
@@ -54,6 +58,13 @@ class SwaggerComponent {
   OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::swagger::Resources>, swaggerResources)
   ([] { return oatpp::swagger::Resources::loadResources(OATPP_SWAGGER_RES_PATH); }());
 };
+#else
+class SwaggerComponent {
+ public:
+  explicit SwaggerComponent(const ListenerConfig& config)
+  {}
+};
+#endif
 }// namespace sdb
 
 #endif /* SWAGGER_COMPONENT_H */

--- a/embedded_server/dto/EventDto.h
+++ b/embedded_server/dto/EventDto.h
@@ -89,10 +89,18 @@ class Variable : public oatpp::DTO {
   DTO_FIELD(UInt64, valueRawAddress);
   DTO_FIELD(UInt32, childCount);
   DTO_FIELD(String, instanceClassName);
+  DTO_FIELD(Boolean, editable);
 };
 
-class VariableList : public CommandMessageResponse {
-  DTO_INIT(VariableList, CommandMessageResponse)
+class VariableSetValueBody : public oatpp::DTO {
+  DTO_INIT(VariableSetValueBody, DTO);
+
+  DTO_FIELD(Enum<VariableType>, valueType);
+  DTO_FIELD(String, value);
+};
+
+class VariableListResponse : public CommandMessageResponse {
+  DTO_INIT(VariableListResponse, CommandMessageResponse)
 
   DTO_FIELD(List<Object<Variable>>, variables);
 };
@@ -105,8 +113,8 @@ class ImmediateValue : public oatpp::DTO {
   DTO_FIELD(List<UInt32>, iteratorPath);
 };
 
-class ImmediateValueList : public CommandMessageResponse {
-  DTO_INIT(ImmediateValueList, CommandMessageResponse)
+class ImmediateValueListResponse : public CommandMessageResponse {
+  DTO_INIT(ImmediateValueListResponse, CommandMessageResponse)
 
   DTO_FIELD(List<Object<ImmediateValue>>, values);
 };

--- a/interfaces/include/sdb/MessageInterface.h
+++ b/interfaces/include/sdb/MessageInterface.h
@@ -80,6 +80,7 @@ struct Variable {
   uint32_t childCount = 0;
   // If valueType is Instance, this is set with the full class name.
   std::string instanceClassName;
+  bool editable = false;
 };
 struct PaginationInfo {
   uint32_t beginIterator;
@@ -157,6 +158,10 @@ class MessageCommandInterface {
 
   [[nodiscard]] virtual data::ReturnCode GetGlobalVariables(
           const std::string& path, const data::PaginationInfo& pagination, std::vector<data::Variable>& variables) = 0;
+
+  [[nodiscard]] virtual data::ReturnCode SetStackVariableValue(
+          uint32_t stackFrame, const std::string& path, const std::string& newValueString, data::Variable& newValue) = 0;
+
 
   /// <summary>
   /// Evaluate the expression in the scope of this stack frame. If -1, the expression is evaluated in the global scope.

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,8 @@ Also included (but optional) is an HTTP server that provides remote-debug capabi
 - *embedded_server* 
     - uses OATPP to host an HTTP server. This acts as an endpoint for debug user interfaces to control the application. 
     - Provides an implementation of `MessageEventInterface`.
+    - Exposes a "Swagger" interface that's accessible via the browser. Located by default at http://localhost:8000/swagger/ui. 
+    - Swagger can be disabled by setting the cmake option `SDB_ENABLE_OATPP_SWAGGER=OFF`. This will save ~200KB binary size in release builds.  
 - *squirrel_debugger* 
     - Implementation of the Squirrel Debug API. Uses semaphores to lock the squirrel execution thread at breakpoints, and provides access to VM stack & variables.
     - Provides an implementation of `MessageCommandInterface`.
@@ -35,15 +37,16 @@ First versioned release, 'MVP'
 [x] Global Variables
 [x] Simple Breakpoints
 [x] Output redirection & capture
+[x] Disablement of the swagger UI on startup
+[x] Modification of variable values (int, bool, float and string only.)
 
 ## Not Currently Supported
 [ ] Multiple VM's (threads)
 [ ] Conditional breakpoints
-[ ] Modification of variable values (int and string only?)
 [ ] Immediate window for execution
 [ ] MacOS / Linux support
 [ ] squirrel unicode builds
-[ ] Disablement of the swagger UI on startup
+[ ] Modification of local & free variables. (No need to support modification of globals)
 
 # Building Sample from source using CMake
 Currently, only support building on windows using CMake. This requires that you have Visual Studio 2019 installed.

--- a/sample_app/CMakeLists.txt
+++ b/sample_app/CMakeLists.txt
@@ -30,7 +30,14 @@ FetchContent_Declare(
     # v1.4
     GIT_TAG 35a173f7897df985697f4c4d282451b9dafe1b61
 )
-FetchContent_MakeAvailable(tclap)
+
+# MakeAvailable will include all the tclap tests. Don't need those, and it doesn't have a flag to disable them.
+# FetchContent_MakeAvailable(tclap)
+FetchContent_GetProperties(tclap)
+if(NOT tclap_POPULATED)
+    FetchContent_Populate(tclap)
+endif()
+
 
 target_include_directories(${PROJECT_NAME} PRIVATE "${tclap_SOURCE_DIR}/include")
 target_link_libraries(${PROJECT_NAME}

--- a/squirrel_debugger/CMakeLists.txt
+++ b/squirrel_debugger/CMakeLists.txt
@@ -40,3 +40,11 @@ target_link_libraries(${PROJECT_NAME}
         sdb::interfaces
         squirrel::squirrel_static
         squirrel::sqstdlib_static)
+
+#####
+# Testing
+#####
+if(SDB_BUILD_TESTING)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/squirrel_debugger/SquirrelVmHelpers.h
+++ b/squirrel_debugger/SquirrelVmHelpers.h
@@ -13,8 +13,12 @@
 #include <stdexcept>
 
 #include <string>
+#include <functional>
 
 namespace sdb::sq {
+
+using PathPartConstIter = std::vector<uint64_t>::const_iterator;
+
 enum class ExpressionNodeType { Undefined, String, Number, Identifier };
 
 struct ExpressionNode {
@@ -30,10 +34,13 @@ data::VariableType ToVariableType(SQObjectType sqType);
 std::string ToClassFullName(HSQUIRRELVM v, SQInteger idx);
 std::string ToString(HSQUIRRELVM v, SQInteger idx);
 
+data::ReturnCode UpdateFromString(SQVM* const v, SQInteger objIdx, const std::string& value);
+
 data::ReturnCode CreateChildVariable(HSQUIRRELVM v, data::Variable& variable);
 data::ReturnCode CreateChildVariablesFromIterable(
-        HSQUIRRELVM v, std::vector<uint64_t>::const_iterator pathBegin, std::vector<uint64_t>::const_iterator pathEnd,
+        HSQUIRRELVM v, PathPartConstIter pathBegin, PathPartConstIter pathEnd,
         const data::PaginationInfo& pagination, std::vector<data::Variable>& variables);
+data::ReturnCode WithVariableAtPath(SQVM* v, PathPartConstIter pathBegin, PathPartConstIter pathEnd, const std::function<data::ReturnCode()>& fn);
 
 struct SqExpressionNode {
   std::unique_ptr<SqExpressionNode> next;

--- a/squirrel_debugger/include/sdb/SquirrelDebugger.h
+++ b/squirrel_debugger/include/sdb/SquirrelDebugger.h
@@ -22,6 +22,8 @@ struct SquirrelVmDataImpl;
 
 class SquirrelDebugger final : public MessageCommandInterface {
  public:
+  static constexpr const char kPathSeparator = ',';
+
   SquirrelDebugger();
   ~SquirrelDebugger() override;
 
@@ -34,6 +36,7 @@ class SquirrelDebugger final : public MessageCommandInterface {
   // Initialization - should be called before any threads are started.
   void SetEventInterface(std::shared_ptr<MessageEventInterface> eventInterface);
   void AddVm(HSQUIRRELVM vm);
+  void DetachVm(HSQUIRRELVM vm);
 
   // The following methods may be called from any thread.
   [[nodiscard]] data::ReturnCode PauseExecution() override;
@@ -49,6 +52,9 @@ class SquirrelDebugger final : public MessageCommandInterface {
   [[nodiscard]] data::ReturnCode GetGlobalVariables(
           const std::string& path, const data::PaginationInfo& pagination,
           std::vector<data::Variable>& variables) override;
+
+  [[nodiscard]] data::ReturnCode SetStackVariableValue(
+          uint32_t stackFrame, const std::string& path, const std::string& newValueString, data::Variable& newValue) override;
 
   [[nodiscard]] data::ReturnCode SetFileBreakpoints(
           const std::string& file, const std::vector<data::CreateBreakpoint>& createBps,

--- a/squirrel_debugger/tests/CMakeLists.txt
+++ b/squirrel_debugger/tests/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.19.2)
+
+project(squirrel_debugger_tests)
+
+################################
+# GTest
+################################
+include(FetchContent)
+FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG        release-1.11.0
+)
+
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
+set(BUILD_GTEST ON CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(googletest)
+
+################################
+# Tests
+################################
+# Add test cpp file
+add_executable(${PROJECT_NAME} testmain.cpp DebuggerTestUtils.cpp DebuggerTestUtils.h)
+# Link test executable against gtest & gtest_main
+target_link_libraries(${PROJECT_NAME} gtest gtest_main sdb::squirrel_debugger)
+enable_testing()
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
+
+configure_file(test.nut test.nut COPYONLY)

--- a/squirrel_debugger/tests/DebuggerTestUtils.cpp
+++ b/squirrel_debugger/tests/DebuggerTestUtils.cpp
@@ -1,0 +1,276 @@
+#include "DebuggerTestUtils.h"
+
+#include <sqstdio.h>
+#include <sqstdmath.h>
+#include <sqstdstring.h>
+#include <sqstdsystem.h>
+
+using sdb::SquirrelDebugger;
+using sdb::data::ReturnCode;
+using sdb::data::RunState;
+
+namespace sdb::tests {
+class MessageEventInterfaceImpl : public sdb::MessageEventInterface {
+ public:
+  void GetLastStatus(sdb::data::Status& status)
+  {
+    std::unique_lock<std::mutex> lock(statusMutex_);
+    status = lastStatus_;
+  }
+  void ResetWaitForStatus()
+  {
+    receivedStatus_ = false;
+  }
+  // Returns true if status was found without timeout being reached
+  bool WaitForStatus(RunState runState)
+  {
+    std::unique_lock<std::mutex> lock(statusMutex_);
+    if (receivedStatus_ && runState == lastStatus_.runState) {
+      return true;
+    }
+
+    while (!receivedStatus_ || runState != lastStatus_.runState) {
+      auto cvStatus = statusCv_.wait_for(lock, std::chrono::seconds(1));
+      if (cvStatus == std::cv_status::timeout) {
+        GTEST_NONFATAL_FAILURE_("Reached timeout before test could begin.");
+        return false;
+      }
+    }
+    return true;
+  }
+  void HandleStatusChanged(const sdb::data::Status& status)
+  {
+    std::unique_lock<std::mutex> lock(statusMutex_);
+    receivedStatus_ = true;
+    lastStatus_ = status;
+    statusCv_.notify_all();
+  }
+  void HandleOutputLine(const sdb::data::OutputLine& outputLine) {}
+
+ private:
+  std::mutex statusMutex_;
+  std::condition_variable statusCv_;
+  sdb::data::Status lastStatus_;
+  bool receivedStatus_ = false;
+};
+
+SQInteger SquirrelFileLexFeedAscii(SQUserPointer file);
+void SquirrelNativeDebugHook(SQVM* v, SQInteger type, const SQChar* sourceName, SQInteger line, const SQChar* funcName);
+void SquirrelPrintCallback(HSQUIRRELVM vm, const SQChar* text, ...);
+void SquirrelPrintErrCallback(HSQUIRRELVM vm, const SQChar* text, ...);
+
+void SquirrelDebuggerTest::HandleOutputLine(
+        SQVM* const vm, const bool isErr, const SQChar* text, char* const args) const
+{
+  std::array<char, 1024> buffer;
+  const auto size = vsprintf_s(buffer.data(), 1024, text, args);
+  if (size > 0) {
+    const std::string_view str = {&buffer[0], static_cast<std::string_view::size_type>(size)};
+    if (debugger_ != nullptr) {
+      debugger_->SquirrelPrintCallback(vm, isErr, str);
+    }
+  }
+}
+
+void SquirrelDebuggerTest::HandleDebugHook(
+        SQVM* const v, const SQInteger type, const SQChar* sourceName, const SQInteger line,
+        const SQChar* const funcName)
+{
+  debugger_->SquirrelNativeDebugHook(v, type, sourceName, line, funcName);
+}
+
+void SquirrelDebuggerTest::SetUp()
+{
+  debugger_ = std::make_unique<SquirrelDebugger>();
+  eventInterface_ = std::make_shared<MessageEventInterfaceImpl>();
+  debugger_->SetEventInterface(eventInterface_);
+
+  GTEST_ASSERT_EQ(nullptr, gInstance);
+  gInstance = this;
+
+  CreateVm();
+}
+
+void SquirrelDebuggerTest::TearDown()
+{
+  if (debugger_) {
+    debugger_->DetachVm(vm_);
+    eventInterface_ = {};
+  }
+  if (squirrelWorker_.joinable()) {
+    squirrelWorker_.join();
+  }
+  debugger_ = {};
+
+  if (vm_) {
+    sq_close(vm_);
+    vm_ = nullptr;
+  }
+  gInstance = nullptr;
+}
+
+void SquirrelDebuggerTest::CreateVm()
+{
+  vm_ = sq_open(SquirrelDebugger::DefaultStackSize());
+
+  // Forward squirrel print & errors streams
+  sq_setprintfunc(vm_, SquirrelPrintCallback, SquirrelPrintErrCallback);
+
+  // Enable debugging hooks
+  debugger_->AddVm(vm_);
+  const auto rc = debugger_->PauseExecution();
+  ASSERT_EQ(ReturnCode::Success, rc);
+
+  sq_enabledebuginfo(vm_, SQTrue);
+  sq_setnativedebughook(vm_, &SquirrelNativeDebugHook);
+
+  // Register stdlibs
+  sq_pushroottable(vm_);
+  sqstd_register_iolib(vm_);
+  sqstd_register_mathlib(vm_);
+  sqstd_register_stringlib(vm_);
+  sqstd_register_systemlib(vm_);
+}
+
+void SquirrelDebuggerTest::RunAndPauseTestFile(const char* const testFileName)
+{
+  {
+    FILE* fpRaw = nullptr;
+    fopen_s(&fpRaw, testFileName, "rb");
+    ASSERT_TRUE(fpRaw != nullptr) << "Test file must exist";
+
+    const std::unique_ptr<std::FILE, decltype(&std::fclose)> fp = {fpRaw, &std::fclose};
+    const auto res = sq_compile(vm_, SquirrelFileLexFeedAscii, fp.get(), testFileName, 1);
+    ASSERT_TRUE(SQ_SUCCEEDED(res)) << "Test file must compile successfully";
+  }
+
+  sq_pushroottable(vm_);
+
+  auto taskWorker = [vm = vm_]() {
+    if (!SQ_SUCCEEDED(sq_call(vm, 1 /* root table */, SQFalse, SQTrue))) {
+      GTEST_NONFATAL_FAILURE_("Failed to execute script");
+    }
+    sq_pop(vm, 1);// Pop function
+  };
+  squirrelWorker_ = std::thread(taskWorker);
+
+  eventInterface_->WaitForStatus(RunState::Paused);
+}
+
+void SquirrelDebuggerTest::RunAndPauseTestFileAtLine(
+        const char* const testFileName, const sdb::data::CreateBreakpoint& bp)
+{
+  RunAndPauseTestFile(testFileName);
+
+  std::vector<sdb::data::CreateBreakpoint> createBps;
+  createBps.push_back(bp);
+  std::vector<sdb::data::ResolvedBreakpoint> resolvedBps;
+  ASSERT_EQ(ReturnCode::Success, GetDebugger().SetFileBreakpoints(testFileName, createBps, resolvedBps));
+
+  ResetWaitForStatus();
+  ASSERT_EQ(ReturnCode::Success, GetDebugger().ContinueExecution());
+  WaitForStatus(RunState::Paused);
+}
+
+SquirrelDebugger& SquirrelDebuggerTest::GetDebugger()
+{
+  return *debugger_.get();
+}
+
+void SquirrelDebuggerTest::ResetWaitForStatus()
+{
+  eventInterface_->ResetWaitForStatus();
+}
+bool SquirrelDebuggerTest::WaitForStatus(RunState runState)
+{
+  return eventInterface_->WaitForStatus(runState);
+}
+void SquirrelDebuggerTest::GetLastStatus(sdb::data::Status& status)
+{
+  eventInterface_->GetLastStatus(status);
+}
+
+SQInteger SquirrelFileLexFeedAscii(SQUserPointer file)
+{
+  char c = 0;
+  if (fread(&c, sizeof(c), 1, static_cast<FILE*>(file)) > 0) {
+    return c;
+  }
+  return 0;
+}
+void SquirrelNativeDebugHook(
+        SQVM* const v, const SQInteger type, const SQChar* sourceName, const SQInteger line,
+        const SQChar* const funcName)
+{
+  SquirrelDebuggerTest::Instance().HandleDebugHook(v, type, sourceName, line, funcName);
+}
+void SquirrelPrintCallback(HSQUIRRELVM vm, const SQChar* text, ...)
+{
+  va_list vl;
+  va_start(vl, text);
+  SquirrelDebuggerTest::Instance().HandleOutputLine(vm, false, text, vl);
+  va_end(vl);
+}
+
+void SquirrelPrintErrCallback(HSQUIRRELVM vm, const SQChar* text, ...)
+{
+  va_list vl;
+  va_start(vl, text);
+  SquirrelDebuggerTest::Instance().HandleOutputLine(vm, true, text, vl);
+  va_end(vl);
+}
+SquirrelDebuggerTest* SquirrelDebuggerTest::gInstance = nullptr;
+}
+
+namespace sdb::log {
+inline int vasprintf(char** strp, const char* format, va_list ap)
+{
+  int len = _vscprintf(format, ap);
+  if (len < 0)
+  {
+    return -1;
+  }
+
+  char* str = static_cast<char*>(malloc(len + 1));
+  if (!str)
+  {
+    return -1;
+  }
+
+#if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
+  int retval = _vsnprintf(str, len + 1, format, ap);
+#else
+  int retval = _vsnprintf_s(str, len + 1, len, format, ap);
+#endif
+  if (retval < 0)
+  {
+    free(str);
+    return -1;
+  }
+
+  *strp = str;
+  return retval;
+}
+
+void LogString(const char* tag, const size_t line, const Level level, const char* str)
+{
+  static constexpr std::array<const char*, 5> levelNames {
+          "Verbose", "Debug"," Info", "Warning","Error"
+  };
+  std::cout <<  "[" << levelNames.at(size_t(level)) << "] " << tag << ":" << line << " " << str << std::endl;
+}
+void LogFormatted(const char* tag, const size_t line, const Level level, const char* message, ...)
+{
+  va_list ap;
+  va_start(ap, message);
+
+  char* str = nullptr;
+  int len = vasprintf(&str, message, ap);
+  static_cast<void>(len);
+  va_end(ap);
+
+  LogString(tag, line, level, str);
+
+  free(str);
+}
+}// namespace sdb::log

--- a/squirrel_debugger/tests/DebuggerTestUtils.h
+++ b/squirrel_debugger/tests/DebuggerTestUtils.h
@@ -1,0 +1,68 @@
+//
+// Created by Lewis weaver on 5/31/2021.
+//
+#pragma once
+
+#ifndef SDB_SQUIRREL_DEBUGGER_DEBUGGERTESTUTILS_H
+#define SDB_SQUIRREL_DEBUGGER_DEBUGGERTESTUTILS_H
+
+#include "gtest/gtest.h"
+
+#include <sdb/LogInterface.h>
+#include <sdb/SquirrelDebugger.h>
+
+#include <cstdarg>
+#include <array>
+#include <thread>
+
+namespace sdb::tests {
+
+class MessageEventInterfaceImpl;
+
+class SquirrelDebuggerTest : public testing::Test
+{
+ public:
+
+  static constexpr const sdb::data::PaginationInfo kPagination {0,100};
+
+  static SquirrelDebuggerTest& Instance() { return *gInstance; }
+
+  void HandleOutputLine(SQVM* vm, bool isErr, const SQChar* text, char* args) const;
+
+  void HandleDebugHook(SQVM* v, SQInteger type, const SQChar* sourceName, SQInteger line,
+                       const SQChar* funcName);
+
+ protected:
+  void SetUp() override;
+
+  void TearDown() override;
+
+  void CreateVm();
+
+  void RunAndPauseTestFile(const char* testFileName);
+
+  void RunAndPauseTestFileAtLine(const char* testFileName, const sdb::data::CreateBreakpoint& bp);
+
+  SquirrelDebugger& GetDebugger();
+
+  void ResetWaitForStatus();
+
+  bool WaitForStatus(sdb::data::RunState runState);
+
+  void GetLastStatus(sdb::data::Status& status);
+
+ private:
+
+  std::unique_ptr<SquirrelDebugger> debugger_;
+  HSQUIRRELVM vm_ = nullptr;
+  static SquirrelDebuggerTest* gInstance;
+
+  std::shared_ptr<MessageEventInterfaceImpl> eventInterface_;
+  std::thread squirrelWorker_;
+};
+
+
+}
+
+
+#endif//SDB_SQUIRREL_DEBUGGER_DEBUGGERTESTUTILS_H

--- a/squirrel_debugger/tests/test.nut
+++ b/squirrel_debugger/tests/test.nut
@@ -1,0 +1,69 @@
+// Test out printing
+::print("This is a print")
+::print(" on the same line\n")
+::error("This is an error")
+
+class BaseVector {
+    constructor(...)
+    {
+        if (vargv.len() >= 3) {
+            x = vargv[0]
+            y = vargv[1]
+            z = vargv[2]
+        }
+    }
+
+
+    x = 0
+    y = 0
+    z = 0
+}
+
+local class Vector3 extends BaseVector {
+    function _add(other)
+    {
+        local cls = this.getclass()
+        if (other instanceof cls)
+            return cls(x+other.x,y+other.y,z+other.z)
+        else
+            throw "wrong parameter";
+    }
+    function Print()
+    {
+        ::print($"{x}, {y}, {z}\n")
+    }
+}
+
+local v0 = Vector3(1,2,3)
+local v1 = Vector3(11,12,13)
+local v2 = v0 + v1
+v2.Print()
+
+::FakeNamespace <- {
+    Utils = {}
+}
+
+FakeNamespace.Utils.SuperClass <- class  {
+    constructor(a, b, c, d, e, f) {
+        ::print("FakeNamespace.Utils.SuperClass (a=" + a + ")\n")
+    }
+}
+
+local c = function(a, b, c) {
+  return 1;
+}
+
+local lambdaExp = @(a,b) a + b
+local strExp = "string expr"
+local mytable = {
+    ["apple pie"]="A1",
+    [strExp]=["one","two","three"],
+    [lambdaExp]=["mary","had","a","little","lamb"],
+    a=10,
+    b=function(a) { return a+1; },
+    c=[9,8,7,6,5,4,3,2,1],
+    d="cat",
+    e="longstring",
+    f=9
+}
+local testy = FakeNamespace.Utils.SuperClass("asdf", 123, lambdaExp, ["I'm a string", [1,2,3,4,5,6,7,8]], mytable, BaseVector)

--- a/squirrel_debugger/tests/testmain.cpp
+++ b/squirrel_debugger/tests/testmain.cpp
@@ -1,0 +1,137 @@
+#include "DebuggerTestUtils.h"
+
+#include <sdb/SquirrelDebugger.h>
+
+#include <array>
+#include <thread>
+
+using sdb::SquirrelDebugger;
+using sdb::data::ReturnCode;
+using sdb::data::RunState;
+
+namespace sdb::tests {
+class SquirrelDebuggerVariablesTest : public SquirrelDebuggerTest {
+ public:
+  // Fixtures
+  static constexpr const char* kTestFileName = "test.nut";
+  static constexpr int kBpLineNumber = 58;// nb - line numbers start at 1
+  static constexpr int kBpId = 4322;
+  static constexpr const char* kStrExpValue = "string expr";
+  static constexpr const char* kv0XValue = "1";
+};
+
+TEST_F(SquirrelDebuggerVariablesTest, GetLocalVariableTest)
+{
+  RunAndPauseTestFile(kTestFileName);
+
+  std::vector<sdb::data::CreateBreakpoint> createBps;
+  createBps.push_back({kBpId, kBpLineNumber});
+  std::vector<sdb::data::ResolvedBreakpoint> resolvedBps;
+  ASSERT_EQ(ReturnCode::Success, GetDebugger().SetFileBreakpoints(kTestFileName, createBps, resolvedBps));
+  ASSERT_EQ(resolvedBps.size(), 1);
+  ASSERT_EQ(resolvedBps.at(0).id, kBpId);
+  ASSERT_EQ(resolvedBps.at(0).line, kBpLineNumber);
+
+  ResetWaitForStatus();
+  ASSERT_EQ(ReturnCode::Success, GetDebugger().ContinueExecution());
+  WaitForStatus(RunState::Paused);
+
+  // Validate that the thread paused at the right spot
+  sdb::data::Status status;
+  GetLastStatus(status);
+  ASSERT_EQ(status.pausedAtBreakpointId, kBpId);
+  ASSERT_FALSE(status.stack.empty());
+  ASSERT_EQ(status.stack[0].line, kBpLineNumber);
+
+  // Check local variable
+  std::vector<sdb::data::Variable> variables;
+  ASSERT_EQ(ReturnCode::Success, GetDebugger().GetStackVariables(0, "", kPagination, variables));
+
+  auto pos = std::find_if(variables.begin(), variables.end(), [](const sdb::data::Variable& var) {
+    return var.pathUiString == "strExp";
+  });
+  ASSERT_NE(pos, variables.end());
+  ASSERT_EQ(pos->value, kStrExpValue);
+}
+
+TEST_F(SquirrelDebuggerVariablesTest, SetStackStringVariableTest)
+{
+  RunAndPauseTestFileAtLine(kTestFileName, {kBpId, kBpLineNumber});
+
+  // Check root local variable
+  std::vector<sdb::data::Variable> variables;
+  ASSERT_EQ(ReturnCode::Success, GetDebugger().GetStackVariables(0, "", kPagination, variables));
+
+  //////////
+  // Local string variable
+  auto strExpPos = std::find_if(variables.begin(), variables.end(), [](const sdb::data::Variable& var) {
+    return var.pathUiString == "strExp";
+  });
+  ASSERT_NE(strExpPos, variables.end());
+  ASSERT_EQ(strExpPos->value, kStrExpValue);
+  ASSERT_EQ(strExpPos->editable, false);
+
+  // Attempt to set the new value - this should fail, can't set top level variable values.
+  {
+    std::stringstream ssPathIter;
+    ssPathIter << strExpPos->pathIterator;
+    const std::string newValueString = "new value";
+    sdb::data::Variable newValueOut;
+    ASSERT_EQ(
+            ReturnCode::InvalidParameter,
+            GetDebugger().SetStackVariableValue(0, ssPathIter.str(), newValueString, newValueOut));
+  }
+}
+
+TEST_F(SquirrelDebuggerVariablesTest, SetStackInstanceVariableTest)
+{
+  RunAndPauseTestFileAtLine(kTestFileName, {kBpId, kBpLineNumber});
+
+  // Check root local variable
+  std::vector<sdb::data::Variable> variables;
+  ASSERT_EQ(ReturnCode::Success, GetDebugger().GetStackVariables(0, "", kPagination, variables));
+
+  //////////
+  // Local class instance variable
+  auto v0Pos = std::find_if(variables.begin(), variables.end(), [](const sdb::data::Variable& var) {
+    return var.pathUiString == "v0";
+  });
+  ASSERT_NE(v0Pos, variables.end());
+
+  std::vector<sdb::data::Variable> v0variables;
+  std::string v0path = std::to_string(v0Pos->pathIterator);
+  ASSERT_EQ(ReturnCode::Success, GetDebugger().GetStackVariables(0, v0path, kPagination, v0variables));
+  ASSERT_EQ(v0Pos->childCount, 5);
+  ASSERT_EQ(v0variables.size(), 5);
+  // Will be sorted: Class methods/fields sorted a-z, then Parent class methods/fields sorted a-z
+  ASSERT_EQ(v0variables[0].pathUiString, "Print");
+  ASSERT_EQ(v0variables[1].pathUiString, "constructor");
+  ASSERT_EQ(v0variables[2].pathUiString, "x");
+  ASSERT_EQ(v0variables[3].pathUiString, "y");
+  ASSERT_EQ(v0variables[4].pathUiString, "z");
+
+  const std::string newValueString = "99";
+  sdb::data::Variable newValueOut;
+
+  // Can set v0.x as it is a child variable.
+  {
+    ASSERT_EQ(v0variables[2].editable, true);
+    std::string v0xpath = v0path + SquirrelDebugger::kPathSeparator + std::to_string(v0variables[2].pathIterator);
+    ASSERT_EQ(ReturnCode::Success, GetDebugger().SetStackVariableValue(0, v0xpath, newValueString, newValueOut));
+    ASSERT_EQ(newValueOut.value, newValueString);
+  }
+
+  // Can't set v0.Print, as it's current value is not a primitive type.
+  {
+    ASSERT_EQ(v0variables[0].editable, false);
+    std::string v0Printpath = v0path + SquirrelDebugger::kPathSeparator + std::to_string(v0variables[0].pathIterator);
+    ASSERT_EQ(ReturnCode::InvalidParameter, GetDebugger().SetStackVariableValue(0, v0Printpath, newValueString, newValueOut));
+  }
+
+  // Can't set v0 as it's a local variable on the current closure.
+  {
+    ASSERT_EQ(v0Pos->editable, false);
+    ASSERT_EQ(ReturnCode::InvalidParameter, GetDebugger().SetStackVariableValue(0, v0path, newValueString, newValueOut));
+  }
+}
+}// namespace sdb::tests


### PR DESCRIPTION
No support for editing global variables (in the root table), primitive local variables, primitive function arguments. Right now can only edit members of local instances, tables, arrays.

Also added ability to disable swagger in the build.